### PR TITLE
Add water isotope forcing to datm

### DIFF
--- a/components/data_comps/datm/bld/build-namelist
+++ b/components/data_comps/datm/bld/build-namelist
@@ -389,6 +389,13 @@ my $var   = "DATM_PRESAERO";
 my $group = $definition->get_group_name($var);
 $nl->set_variable_value( $group, $var, "\'$xmlvars{$var}\'" );
 
+# water istotpes, depends on DATM_MODE, and affects the selection of the stream datasets as well
+# as data passed to the coupler.
+if ($DATM_MODE =~ /CLM_QIAN_WISO/) {
+  add_default($nl, "wiso_datm", 'val'=>'.true.');
+  $DATM_MODE = "CLM_QIAN";
+}
+
 ####################################
 # Streams file(s)                  #
 ####################################
@@ -414,6 +421,7 @@ $default_namelist_opts{'atm_grid'}         = $ATM_GRID;
 $default_namelist_opts{'datm_mode'}        = $DATM_MODE;
 $default_namelist_opts{'presaero_mode'}    = $DATM_PRESAERO;
 $default_namelist_opts{'datm_co2_tseries'} = $DATM_CO2_TSERIES;
+$default_namelist_opts{'wiso_datm'} = $nl->get_value('wiso_datm');
 
 # Create streams template file(s) - loop over streams
 my $streams = $defaults->get_value( "streamslist", \%default_namelist_opts );

--- a/components/data_comps/datm/bld/namelist_files/namelist_defaults_datm.xml
+++ b/components/data_comps/datm/bld/namelist_files/namelist_defaults_datm.xml
@@ -427,6 +427,7 @@ Currently the following streams are supported (term definitions precede the stre
 <strm_domdir     stream="CLM_QIAN.Solar">$DIN_LOC_ROOT/atm/datm7</strm_domdir>
 <strm_domfil     stream="CLM_QIAN.Solar">domain.T62.050609.nc</strm_domfil>
 <strm_datdir     stream="CLM_QIAN.Solar">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.Qian.T62.c080727/Solar6Hrly</strm_datdir>
+<strm_datdir     stream="CLM_QIAN.Solar" wiso_datm=".true.">$DIN_LOC_ROOT/atm/datm7/atm_forcing_iso.datm7.Qian.T62.c080727/Solar6Hrly</strm_datdir>
 <strm_datfil     stream="CLM_QIAN.Solar">clmforc.Qian.c2006.T62.Solr.%ym.nc</strm_datfil>
 <strm_offset     stream="CLM_QIAN.Solar">0</strm_offset>
 <strm_tintalgo   stream="CLM_QIAN.Solar">coszen</strm_tintalgo>
@@ -450,6 +451,7 @@ Currently the following streams are supported (term definitions precede the stre
 <strm_domdir     stream="CLM_QIAN.Precip">$DIN_LOC_ROOT/atm/datm7</strm_domdir>
 <strm_domfil     stream="CLM_QIAN.Precip">domain.T62.050609.nc</strm_domfil>
 <strm_datdir     stream="CLM_QIAN.Precip">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.Qian.T62.c080727/Precip6Hrly</strm_datdir>
+<strm_datdir     stream="CLM_QIAN.Precip" wiso_datm=".true.">$DIN_LOC_ROOT/atm/datm7/atm_forcing_iso.datm7.Qian.T62.c080727/Precip6Hrly</strm_datdir>
 <strm_datfil     stream="CLM_QIAN.Precip">clmforc.Qian.c2006.T62.Prec.%ym.nc</strm_datfil>
 <strm_offset     stream="CLM_QIAN.Precip">0</strm_offset>
 <strm_tintalgo   stream="CLM_QIAN.Precip">nearest</strm_tintalgo>
@@ -473,6 +475,7 @@ Currently the following streams are supported (term definitions precede the stre
 <strm_domdir     stream="CLM_QIAN.TPQW">$DIN_LOC_ROOT/atm/datm7</strm_domdir>
 <strm_domfil     stream="CLM_QIAN.TPQW">domain.T62.050609.nc</strm_domfil>
 <strm_datdir     stream="CLM_QIAN.TPQW">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.Qian.T62.c080727/TmpPrsHumWnd3Hrly</strm_datdir>
+<strm_datdir     stream="CLM_QIAN.TPQW" wiso_datm=".true.">$DIN_LOC_ROOT/atm/datm7/atm_forcing_iso.datm7.Qian.T62.c080727/TmpPrsHumWnd3Hrly</strm_datdir>
 <strm_datfil     stream="CLM_QIAN.TPQW">clmforc.Qian.c2006.T62.TPQW.%ym.nc</strm_datfil>
 <strm_offset     stream="CLM_QIAN.TPQW">0</strm_offset>
 <strm_tintalgo   stream="CLM_QIAN.TPQW">linear</strm_tintalgo>
@@ -2620,6 +2623,8 @@ af.rlds.ccsm4.rcp45.2006-2300.nc
 <factorfn stream="CORE2_NYF">$DIN_LOC_ROOT/atm/datm7/CORE2/COREv2.correction_factors.T62.121007.nc</factorfn>
 <factorfn stream="CORE2_IAF">$DIN_LOC_ROOT/atm/datm7/CORE2/COREv2.correction_factors.T62.121007.nc</factorfn>
 <factorfn stream="CORE2_IAF" atm_grid="01col">unused</factorfn> 
+
+<wiso_datm>.false.</wiso_datm>
 
 </namelist_defaults>
 

--- a/components/data_comps/datm/bld/namelist_files/namelist_definition_datm.xml
+++ b/components/data_comps/datm/bld/namelist_files/namelist_definition_datm.xml
@@ -12,7 +12,7 @@
 type="char*256"  
 category="datm_setting"
 group="datm_env_settings" 
-valid_values="CLM_QIAN,CLM1PT,CLMCRUNCEP,CLMCRUNCEP_V5,CLMGSWP3,CPLHIST3HrWx,CORE2_NYF,CORE2_IAF,COPYALL_NPS_v1,COPYALL_CORE2_v1,WW3">
+valid_values="CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEP_V5,CLMGSWP3,CPLHIST3HrWx,CORE2_NYF,CORE2_IAF,COPYALL_NPS_v1,COPYALL_CORE2_v1,WW3">
 Data Model mode to process forcing data
 </entry>
 
@@ -338,6 +338,14 @@ type="logical"
 category="datm"
 group="datm_nml">
 If TRUE, prognostic is forced to true.
+default=false 
+</entry>
+
+<entry id="wiso_datm"
+type="logical" 
+category="datm"
+group="datm_nml">
+If TRUE, expect isotopic forcing from file
 default=false 
 </entry>
 

--- a/components/data_comps/datm/cime_config/config_component.xml
+++ b/components/data_comps/datm/cime_config/config_component.xml
@@ -15,7 +15,7 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,TN460,CLM_QIAN,CLM1PT,CLMCRUNCEP,CLMCRUNCEP_V5,CLMGSWP3,CPLHIST3HrWx,COPYALL_NPS_v1,COPYALL_NPS_CORE2_v1,WRF,WW3</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,TN460,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEP_V5,CLMGSWP3,CPLHIST3HrWx,COPYALL_NPS_v1,COPYALL_NPS_CORE2_v1,WRF,WW3</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -29,6 +29,7 @@
       <value compset="%WW3"  >WW3</value>
       <value compset="%NPS"  >COPYALL_NPS_v1</value>
       <value compset="%NPSC2">COPYALL_NPS_CORE2_v1</value>
+      <value compset="%WISOQIA">CLM_QIAN_WISO</value>
       <value compset="%QIA"  >CLM_QIAN</value>
       <value compset="%CRU"  >CLMCRUNCEP</value>
       <value compset="%GSW"  >CLMGSWP3</value>
@@ -177,6 +178,7 @@
       <value compset="1850.*_DATM%QIA">1948</value>
       <value compset="1850.*_DATM%CRU">1901</value>
       <value compset="1850.*_DATM%GSW">1901</value>
+      <value compset="2000.*_DATM%WISOQIA">2000</value>
       <value compset="2000.*_DATM%QIA">1972</value>
       <value compset="HIST.*_DATM%QIA">1948</value>
       <value compset="HIST.*_DATM%CRU">1901</value>
@@ -207,6 +209,7 @@
       <value   compset="1850.*_DATM%QIA">1972</value> 
       <value   compset="1850.*_DATM%CRU">1920</value> 
       <value   compset="1850.*_DATM%GSW">1920</value> 
+      <value   compset="2000.*_DATM%WISOQIA">2004</value> 
       <value   compset="2000.*_DATM%QIA">2004</value> 
       <value   compset="HIST.*_DATM%QIA">1972</value>
       <value   compset="HIST.*_DATM%CRU">1920</value>
@@ -230,6 +233,7 @@
 
   <description>
     <desc compset="^1850_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>
+    <desc compset="^2000_DATM%WISOQIA"	>QIAN atm input data with water isotopes for 2000-2004:</desc>
     <desc compset="^2000_DATM%QIA"	>QIAN atm input data for 1972-2004:</desc>
     <desc compset="^2003_DATM%QIA"	>QIAN atm input data for 2002-2003:</desc>
     <desc compset="^HIST_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>

--- a/components/data_comps/datm/datm_comp_mod.F90
+++ b/components/data_comps/datm/datm_comp_mod.F90
@@ -102,6 +102,23 @@ module datm_comp_mod
   integer(IN) :: kanidr,kanidf,kavsdr,kavsdf
   integer(IN) :: stbot,swind,sz,spbot,sshum,stdew,srh,slwdn,sswdn,sswdndf,sswdndr
   integer(IN) :: sprecc,sprecl,sprecn,sco2p,sco2d,sswup,sprec,starcf
+
+  !
+  ! water isotopes / tracer input 
+  integer(IN) :: &
+       kshum_16O, kshum_18O, kshum_HDO, &
+       krc_18O, krc_HDO, &
+       krl_18O, krl_HDO, &
+       ksc_18O, ksc_HDO, &
+       ksl_18O, ksl_HDO, &
+       sshum_16O, sshum_18O, sshum_HDO, &
+       srh_16O, srh_18O, srh_HDO, &
+       sprecc_18O, sprecc_HDO, &
+       sprecl_18O, sprecl_HDO, &
+       sprecn_16O, sprecn_18O, sprecn_HDO
+
+  logical, public :: wiso_datm = .false. ! expect isotopic forcing from file?
+
   !
   ! anomaly forcing
   !
@@ -120,7 +137,11 @@ module datm_comp_mod
   !
   ! for anomaly forcing
   !
-  integer(IN),parameter :: ktrans  = 66
+  !X! integer(IN),parameter :: ktrans  = 66
+
+  ! isotopic forcing
+  integer(IN),parameter :: ktrans  = 77
+
 
   character(16),parameter  :: avofld(1:ktrans) = &
        (/"Sa_z            ","Sa_topo         ", &
@@ -144,7 +165,11 @@ module datm_comp_mod
          !
          "Sa_precsf       ", &
          "Sa_prec_af      ","Sa_u_af         ","Sa_v_af         ","Sa_tbot_af      ",&
-         "Sa_pbot_af      ","Sa_shum_af      ","Sa_swdn_af      ","Sa_lwdn_af      " &
+         "Sa_pbot_af      ","Sa_shum_af      ","Sa_swdn_af      ","Sa_lwdn_af      ",&
+         ! isotopic forcing
+         "Faxa_rainc_18O  ","Faxa_rainc_HDO  ","Faxa_rainl_18O  ","Faxa_rainl_HDO  ",&
+         "Faxa_snowc_18O  ","Faxa_snowc_HDO  ","Faxa_snowl_18O  ","Faxa_snowl_HDO  ",&
+         "Sa_shum_16O     ","Sa_shum_18O     ","Sa_shum_HDO     " &
        /)
 
   character(16),parameter  :: avifld(1:ktrans) = &
@@ -167,11 +192,18 @@ module datm_comp_mod
          "dms             ","precsf          ", &                                       
          ! add Sa_precsf for precip scale factor
          "prec_af         ","u_af            ","v_af            ","tbot_af         ", &
-         "pbot_af         ","shum_af         ","swdn_af         ","lwdn_af         "  &
+         "pbot_af         ","shum_af         ","swdn_af         ","lwdn_af         ", &
+         ! isotopic forcing
+         "rainc_18O       ","rainc_HDO       ","rainl_18O       ","rainl_HDO       ", &
+         "snowc_18O       ","snowc_HDO       ","snowl_18O       ","snowl_HDO       ", &
+         "shum_16O        ","shum_18O        ","shum_HDO        " &
        /)
 
   ! add stream for anomaly forcing
-  integer(IN),parameter :: ktranss = 28
+  ! integer(IN),parameter :: ktranss = 28
+  ! isotopic forcing
+  integer(IN),parameter :: ktranss = 33
+
 
   ! The stofld and stifld lists are used for fields that are read but not passed to the
   ! coupler (e.g., they are used to compute fields that are passed to the coupler), and
@@ -186,8 +218,10 @@ module datm_comp_mod
          ! add bias correction / anomaly forcing streams
          "strm_precsf     ", &
          "strm_prec_af    ","strm_u_af       ","strm_v_af       ","strm_tbot_af    ", &
-         "strm_pbot_af    ","strm_shum_af    ","strm_swdn_af    ","strm_lwdn_af    "  &
-       /)
+         "strm_pbot_af    ","strm_shum_af    ","strm_swdn_af    ","strm_lwdn_af    ", &
+         "strm_rh_18O     ","strm_rh_HDO     ", &
+         "strm_precn_16O  ","strm_precn_18O  ","strm_precn_HDO  "  &
+         /)
 
   character(16),parameter  :: stifld(1:ktranss) = &
        (/"tbot            ","wind            ","z               ","pbot            ", &
@@ -198,7 +232,10 @@ module datm_comp_mod
          "swup            ","prec            ","tarcf           ","precsf          ", &
          ! add anomaly forcing streams
          "prec_af         ","u_af            ","v_af            ","tbot_af         ", &
-         "pbot_af         ","shum_af         ","swdn_af         ","lwdn_af         "  &
+         "pbot_af         ","shum_af         ","swdn_af         ","lwdn_af         ", &
+         ! isotopic forcing
+         "rh_18O          ","rh_HDO          ", &
+         "precn_16O       ","precn_18O       ","precn_HDO       "  &
        /)
 
   character(CL), pointer :: ilist_av(:)     ! input list for translation
@@ -294,7 +331,7 @@ subroutine datm_comp_init( EClock, cdata, x2a, a2x, NLFilename )
     !----- define namelist -----
     namelist / datm_nml / &
         atm_in, decomp, iradsw, factorFn, restfilm, restfils, presaero, bias_correct, &
-        anomaly_forcing, force_prognostic_true
+        anomaly_forcing, force_prognostic_true, wiso_datm
 
     !--- formats ---
     character(*), parameter :: F00   = "('(datm_comp_init) ',8a)"
@@ -392,6 +429,7 @@ subroutine datm_comp_init( EClock, cdata, x2a, a2x, NLFilename )
        write(logunit,F00)' restfils = ',trim(restfils)
        write(logunit,F0L)' presaero = ',presaero
        write(logunit,F0L)' force_prognostic_true = ',force_prognostic_true
+       write(logunit,F0L)' wiso_datm = ', wiso_datm
        write(logunit,F01) 'inst_index  =  ',inst_index
        write(logunit,F00) 'inst_name   =  ',trim(inst_name)
        write(logunit,F00) 'inst_suffix =  ',trim(inst_suffix)
@@ -405,6 +443,7 @@ subroutine datm_comp_init( EClock, cdata, x2a, a2x, NLFilename )
     call shr_mpi_bcast(restfils,mpicom,'restfils')
     call shr_mpi_bcast(presaero,mpicom,'presaero')
     call shr_mpi_bcast(force_prognostic_true,mpicom,'force_prognostic_true')
+    call shr_mpi_bcast(wiso_datm, mpicom, 'wiso_datm')
 
     rest_file = trim(restfilm)
     rest_file_strm = trim(restfils)
@@ -568,6 +607,21 @@ subroutine datm_comp_init( EClock, cdata, x2a, a2x, NLFilename )
     kco2p = mct_aVect_indexRA(a2x,'Sa_co2prog',perrWith='quiet')
     kco2d = mct_aVect_indexRA(a2x,'Sa_co2diag',perrWith='quiet')
 
+    !isotopic forcing
+    if(wiso_datm) then
+      kshum_16O = mct_aVect_indexRA(a2x,'Sa_shum_16O')
+      kshum_18O = mct_aVect_indexRA(a2x,'Sa_shum_18O')
+      kshum_HDO = mct_aVect_indexRA(a2x,'Sa_shum_HDO')
+      krc_18O   = mct_aVect_indexRA(a2x,'Faxa_rainc_18O')
+      krc_HDO   = mct_aVect_indexRA(a2x,'Faxa_rainc_HDO')
+      krl_18O   = mct_aVect_indexRA(a2x,'Faxa_rainl_18O')
+      krl_HDO   = mct_aVect_indexRA(a2x,'Faxa_rainl_HDO')
+      ksc_18O   = mct_aVect_indexRA(a2x,'Faxa_snowc_18O')
+      ksc_HDO   = mct_aVect_indexRA(a2x,'Faxa_snowc_HDO')
+      ksl_18O   = mct_aVect_indexRA(a2x,'Faxa_snowl_18O')
+      ksl_HDO   = mct_aVect_indexRA(a2x,'Faxa_snowl_HDO')
+    end if
+
     kbid  = mct_aVect_indexRA(a2x,'Faxa_bcphidry')
     kbod  = mct_aVect_indexRA(a2x,'Faxa_bcphodry')
     kbiw  = mct_aVect_indexRA(a2x,'Faxa_bcphiwet')
@@ -643,6 +697,18 @@ subroutine datm_comp_init( EClock, cdata, x2a, a2x, NLFilename )
     sshum_af = mct_aVect_indexRA(avstrm,'strm_shum_af',perrWith='quiet')
     sswdn_af = mct_aVect_indexRA(avstrm,'strm_swdn_af',perrWith='quiet')
     slwdn_af = mct_aVect_indexRA(avstrm,'strm_lwdn_af',perrWith='quiet')
+
+    if(wiso_datm) then
+       ! isotopic forcing
+      sprecn_16O = mct_aVect_indexRA(avstrm,'strm_precn_16O',perrWith='quiet')
+      sprecn_18O = mct_aVect_indexRA(avstrm,'strm_precn_18O',perrWith='quiet')
+      sprecn_HDO = mct_aVect_indexRA(avstrm,'strm_precn_HDO',perrWith='quiet')
+      ! Okay here to just use srh_18O and srh_HDO, because the forcing is (should)
+      ! just be deltas, applied in lnd_comp_mct to the base tracer
+      srh_16O    = mct_aVect_indexRA(avstrm,'strm_rh_16O',perrWith='quiet')
+      srh_18O    = mct_aVect_indexRA(avstrm,'strm_rh_18O',perrWith='quiet')
+      srh_HDO    = mct_aVect_indexRA(avstrm,'strm_rh_HDO',perrWith='quiet')
+    end if
 
     allocate(imask(lsize))
     allocate(yc(lsize))
@@ -1101,6 +1167,14 @@ subroutine datm_comp_run( EClock, cdata,  x2a, a2x)
             e = avstrm%rAttr(srh,n) * 0.01_R8 * datm_shr_esat(tbot,tbot)
             qsat = (0.622_R8 * e)/(pbot - 0.378_R8 * e)
             a2x%rAttr(kshum,n) = qsat
+            if(wiso_datm) then
+               ! isotopic forcing
+               ! For tracer specific humidity, lnd_import_mct expects a delta, so
+               ! just keep the delta from the input file - TW
+               a2x%rAttr(kshum_16O,n) = avstrm%rAttr(srh_16O,n)
+               a2x%rAttr(kshum_18O,n) = avstrm%rAttr(srh_18O,n)
+               a2x%rAttr(kshum_HDO,n) = avstrm%rAttr(srh_HDO,n)
+            end if
          else if (stdew > 0) then
             if (tdewmax < 50.0_R8) avstrm%rAttr(stdew,n) = avstrm%rAttr(stdew,n) + tkFrz
             e = datm_shr_esat(avstrm%rAttr(stdew,n),tbot)


### PR DESCRIPTION
Adds the coupler fields and flags necessary to read water isotope data from an
input stream.

Test suite: manual testing of:

  SMS_D_Ld3.f10_f10.ICLM50WISO.yellowstone_intel.clm-default.junk-svn-wiso
  SMS_D_Ld3.f10_f10.ICRUCLM50BGC.yellowstone_intel.clm-default.junk-svn-default

Test baseline: none
Test namelist changes: add wiso flags

Test answer changes: no changes expected for existing data, add water isotopes
to coupler output for standalone clm with isotopes on.

Test summary: both tests passed.